### PR TITLE
fix: replay request on access token expires

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -163,6 +163,7 @@ module.exports = class NetworkWrapper {
                   if (err) return next(response)
                   // then we can rebuffer the request
                   loggerHttp(`Re-buffering call to ${httpOpts.url} since authenticated now`)
+                  httpOpts.headers.Authorization = `Bearer ${this.tokens.access_token}`
                   return this._axios.request(httpOpts).then(successNext).catch(next)
                 })
               })


### PR DESCRIPTION
The HTTP headers were not updated with the new access_token when replaying the request, so the request failed again.