### PR TITLE
fix: onopen already called on reconnect

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -344,7 +344,6 @@ module.exports = class NetworkWrapper {
             }
           }
           socket.onopen = onConnect
-          socket.onreconnect = onConnect
 
           socket.onunexpectedresponse = (req, res) => {
             if (res.statusCode === 401) {


### PR DESCRIPTION
Fix the double active message on reconnection (and subscribe 2 times to events, etc...)