### PR TITLE
improv: use a custom header to expose the version

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -3,7 +3,7 @@ const pkg = require('./package.json')
 
 const config = {
   headers: {
-    'User-Agent': `PM2 js-api v${pkg.version}`
+    'X-JS-API-Version': pkg.version
   },
   services: {
     API: 'https://app.keymetrics.io',


### PR DESCRIPTION
In Chrome (and apparently Safari), you can't set the `User-Agent`. This won't break the XHR, just print an error in the devtools console.

Reduced test-case:
```js
var xhr = new XMLHttpRequest()
xhr.open('GET', '/')
xhr.setRequestHeader('User-Agent', 'foo')
xhr.send()
```

Proposal: add a `X-JS-API-Version` instead.