### PR TITLE
Upgrade axios to ^0.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/keymetrics/km.js#readme",
   "dependencies": {
     "async": "^2.6.3",
-    "axios": "^0.19.0",
+    "axios": "^0.21.0",
     "debug": "~3.2.6",
     "eventemitter2": "^6.3.1",
     "ws": "^7.0.0"


### PR DESCRIPTION
axios has a critical (server-side request forgery) security [vulnerability](https://snyk.io/vuln/npm:axios) affecting versions <0.21.1.

This is causing `npm audit` warnings when installing pm2. This PR allows 0.21.1 to be installed, mitigating the problem.

I wasn't sure how to run tests, to unfortunately that hasn't been done. I have no idea if this upgrade is stable.